### PR TITLE
Make `Feature` function for getting values split out subfeatures to own rows

### DIFF
--- a/.github/workflows/TEST_Models.yml
+++ b/.github/workflows/TEST_Models.yml
@@ -26,6 +26,7 @@ jobs:
         testbed: [
           test_DatasetKey,
           test_EventSet,
+          test_Feature,
           test_SemanticVersion,
         ]
       fail-fast: false # we don't want to cancel just because one testbed fails.

--- a/src/ogd/common/models/Feature.py
+++ b/src/ogd/common/models/Feature.py
@@ -139,8 +139,8 @@ class Feature(GameData):
     def ValueMap(self) -> Dict[str, Any]:
         ret_val : Dict[str, Any]
 
-        if len(self.Subfeatures) != len(self.Values):
-            raise ValueError(f"For {self.Name}, number of subfeatures (+1) did not match number of values!")
+        if len(self.FeatureNames) != len(self.Values):
+            raise ValueError(f"For {self.Name}, number of Features did not match number of values!")
         else:
             ret_val = {self.FeatureNames[i] : self.Values[i] for i in range(len(self.FeatureNames))}
         

--- a/src/ogd/common/models/Feature.py
+++ b/src/ogd/common/models/Feature.py
@@ -58,10 +58,10 @@ class Feature(GameData):
         :rtype: List[str]
         """
         return ["name",   "feature_type", "game_unit",  "game_unit_index", 
-                "app_id", "user_id",      "session_id", "subfeatures", "values"]
+                "app_id", "user_id",      "session_id", "value"]
 
     @property
-    def ColumnValues(self) -> List[str | int | List[Any] | None]:
+    def ColumnValues(self) -> List[List[Any]]:
         """A list of all values for the row, in order they appear in the `ColumnNames` function.
 
         .. todo:: Technically, this should be string representations of each, but we're technically not enforcing that yet.
@@ -69,8 +69,13 @@ class Feature(GameData):
         :return: The list of values.
         :rtype: List[Union[str, datetime, timezone, Map, int, None]]
         """
-        return [self.Name,  self.FeatureType, self.GameUnit,  self.GameUnitIndex,
-                self.AppID, self.UserID,      self.SessionID, self.Subfeatures, self.Values]
+        return [
+            [
+                feat_name,  self.FeatureType, self.GameUnit,  self.GameUnitIndex,
+                self.AppID, self.UserID,      self.SessionID, self.ValueMap.get(feat_name)
+            ]
+            for feat_name in self.FeatureNames
+        ]
 
     @property
     def ExportMode(self) -> ExportMode:

--- a/src/ogd/common/models/FeatureSet.py
+++ b/src/ogd/common/models/FeatureSet.py
@@ -1,4 +1,5 @@
 ## import standard libraries
+from itertools import chain
 from typing import List
 # import local files
 from ogd.common.filters.collections import *
@@ -60,16 +61,22 @@ class FeatureSet:
 
     @property
     def FeatureLines(self) -> List[ExportRow]:
-        return [feature.ColumnValues for feature in self.Features]
+        """Property to get all the "ExportRow" lines of the features within the set.
+
+        :return: _description_
+        :rtype: List[ExportRow]
+        """
+        # Since each feature returns a list of rows, we need to chain them to a single list
+        return list(chain.from_iterable(feature.ColumnValues for feature in self.Features))
     @property
     def PopulationLines(self) -> List[ExportRow]:
-        return [feature.ColumnValues for feature in self.PopulationFeatures]
+        return list(chain.from_iterable(feature.ColumnValues for feature in self.PopulationFeatures))
     @property
     def PlayerLines(self) -> List[ExportRow]:
-        return [feature.ColumnValues for feature in self.PlayerFeatures]
+        return list(chain.from_iterable(feature.ColumnValues for feature in self.PlayerFeatures))
     @property
     def SessionLines(self) -> List[ExportRow]:
-        return [feature.ColumnValues for feature in self.SessionFeatures]
+        return list(chain.from_iterable(feature.ColumnValues for feature in self.SessionFeatures))
 
     @property
     def Filters(self) -> DatasetFilterCollection:

--- a/src/ogd/common/models/enums/ExportMode.py
+++ b/src/ogd/common/models/enums/ExportMode.py
@@ -2,12 +2,12 @@
 from enum import IntEnum
 
 class ExportMode(IntEnum):
-    SESSION = 1
-    PLAYER = 2
-    POPULATION = 3
-    FEATURES = 4
-    EVENTS = 5
-    DETECTORS = 6
+    EVENTS     = 1
+    DETECTORS  = 2
+    FEATURES   = 3
+    SESSION    = 4
+    PLAYER     = 5
+    POPULATION = 6
 
     def __str__(self):
         return self.name

--- a/tests/cases/models/test_Feature.py
+++ b/tests/cases/models/test_Feature.py
@@ -1,0 +1,98 @@
+# import libraries
+import logging
+from pathlib import Path
+from unittest import TestCase
+from zipfile import ZipFile
+# import locals
+from ogd.common.configs.TestConfig import TestConfig
+from ogd.common.models.Feature import Feature
+from ogd.common.models.enums.ExportMode import ExportMode
+from ogd.common.utils.Logger import Logger
+# import locals
+from src.ogd.common.models.EventSet import EventSet
+from tests.config.t_config import settings
+
+class test_Feature(TestCase):
+    zipped_file = ZipFile(Path("tests/data/models/BACTERIA_20210201_to_20210202_5c61198_events.zip"))
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # 1. Get testing config
+        _testing_cfg = TestConfig.FromDict(name="FeatureTestConfig", unparsed_elements=settings)
+        _level     = logging.DEBUG if _testing_cfg.Verbose else logging.INFO
+        Logger.std_logger.setLevel(_level)
+
+        # 2. Set up local instance of testing class
+        cls.feature = Feature(
+            name="TestFeature",
+            feature_type="SomeTypeOfFeature",
+            game_unit="*",
+            game_unit_index=None,
+            app_id="AQUALAB",
+            user_id="GreenGiant",
+            session_id="20250101012345",
+            subfeatures=["Foo"],
+            values=["Value", "Bar"]
+        )
+
+    @staticmethod
+    def RunAll():
+        pass
+
+    def test_ColumnNames(self):
+        _elems = [
+            "name",   "feature_type", "game_unit",  "game_unit_index", 
+            "app_id", "user_id",      "session_id", "value"
+        ]
+        self.assertIsInstance(self.feature.ColumnNames(), list)
+        self.assertEqual(self.feature.ColumnNames(), _elems)
+
+    def test_ColumnValues(self):
+        _elems = [
+            [
+                "TestFeature", "SomeTypeOfFeature", "*",              "*", 
+                "AQUALAB",     "GreenGiant",        "20250101012345", "Value"
+            ],
+            [
+                "Foo",     "SomeTypeOfFeature", "*",              "*", 
+                "AQUALAB", "GreenGiant",        "20250101012345", "Bar"
+            ]
+        ]
+        self.assertIsInstance(self.feature.ColumnValues, list)
+        self.assertEqual(self.feature.ColumnValues, _elems)
+
+    def test_ExportMode(self):
+        self.assertIsInstance(self.feature.ExportMode, ExportMode)
+        self.assertEqual(self.feature.ExportMode, ExportMode.SESSION)
+
+    def test_Name(self):
+        self.assertIsInstance(self.feature.Name, str)
+        self.assertEqual(self.feature.Name, "TestFeature")
+
+    def test_FeatureType(self):
+        self.assertIsInstance(self.feature.FeatureType, str)
+        self.assertEqual(self.feature.FeatureType, "SomeTypeOfFeature")
+
+    def test_GameUnit(self):
+        self.assertIsInstance(self.feature.GameUnit, str)
+        self.assertEqual(self.feature.GameUnit, "*")
+
+    def test_GameUnitIndex(self):
+        self.assertIsInstance(self.feature.GameUnitIndex, str)
+        self.assertEqual(self.feature.GameUnitIndex, "*")
+
+    def test_Subfeatures(self):
+        self.assertIsInstance(self.feature.Subfeatures, list)
+        self.assertEqual(self.feature.Subfeatures, ["Foo"])
+
+    def test_FeatureNames(self):
+        self.assertIsInstance(self.feature.FeatureNames, list)
+        self.assertEqual(self.feature.FeatureNames, ["TestFeature", "Foo"])
+
+    def test_Values(self):
+        self.assertIsInstance(self.feature.Values, list)
+        self.assertEqual(self.feature.Values, ["Value", "Bar"])
+
+    def test_ValueMap(self):
+        self.assertIsInstance(self.feature.ValueMap, dict)
+        self.assertEqual(self.feature.ValueMap, {"TestFeature":"Value", "Foo":"Bar"})


### PR DESCRIPTION
Previously, we had a kinda-awkward output format that put subfeatures in a column, and all values in a column, each of which held a list of values. That just didn't fully sit right, so we'll put them into their own rows, since a downstream user really shouldn't care too much about whether a given feature came from the same module as a different "parent" or "sub" feature. They aren't thinking of feature data in terms of such module-specific hierarchies, so just give each thing we would call a "feature" its own row.

Resolves #199 