### PR TITLE
Allow `Logger.Log` to directly deal with leading whitespace

### DIFF
--- a/src/ogd/common/utils/Logger.py
+++ b/src/ogd/common/utils/Logger.py
@@ -53,10 +53,28 @@ class Logger:
             finally:
                 Logger.file_logger.debug("Initialized file logger")
     
-    # Function to print a method to both the standard out and file logs.
-    # Useful for "general" errors where you just want to print out the exception from a "backstop" try-catch block.
     @staticmethod
     def Log(message:str, level=logging.INFO, depth:int=0, whitespace_adjust:Optional[str]=None) -> None:
+        """Function to print a method to both the standard out and file logs.
+
+        Useful for "general" errors where you just want to print out the exception from a "backstop" try-catch block.
+
+        :param message: The log message to display.
+            Some additional formatting, such as displaying the log level, is automatically added.
+        :type message: str
+        :param level: Logging level at which to output the message, defaults to logging.INFO
+        :type level: _type_, optional
+        :param depth: The number of levels to indent the message (indent width=2).
+            This allows for nice indentation of logging messages, useful for complex programs with multiple levels of "nested" behaviors to log.
+            Defaults to 0
+        :type depth: int, optional
+        :param whitespace_adjust: how to handle leading whitespace in the message.
+            If set to 'dedent', shared indentation will be removed, but relative indentation in the message will be preserved.
+            If set to 'lstrip', all leading whitespace on each line will be removed, and relative indentation will be lost.
+            Otherwise, all leading whitespace, including relative indentation, is preserved.
+            Defaults to None
+        :type whitespace_adjust: Optional[str], optional
+        """
         now = datetime.now().strftime("%y-%m-%d %H:%M:%S")
         INDENT_WIDTH = 2
         base_indent = ' '*9

--- a/src/ogd/common/utils/Logger.py
+++ b/src/ogd/common/utils/Logger.py
@@ -54,7 +54,7 @@ class Logger:
                 Logger.file_logger.debug("Initialized file logger")
     
     @staticmethod
-    def Log(message:str, level=logging.INFO, depth:int=0, whitespace_adjust:Optional[str]=None) -> None:
+    def Log(message:str, level:int=logging.INFO, depth:int=0, whitespace_adjust:Optional[str]=None) -> None:
         """Function to print a method to both the standard out and file logs.
 
         Useful for "general" errors where you just want to print out the exception from a "backstop" try-catch block.
@@ -108,6 +108,22 @@ class Logger:
                     Logger.std_logger.warning( f"WARNING: {user_indent}{indented_msg}")
                 case logging.ERROR:
                     Logger.std_logger.error(   f"ERROR:   {user_indent}{indented_msg}")
+
+    @staticmethod
+    def debug(message:str, depth:int=0, whitespace_adjust:Optional[str]=None) -> None:
+        Logger.Log(message=message, level=logging.DEBUG, depth=depth, whitespace_adjust=whitespace_adjust)
+
+    @staticmethod
+    def info(message:str, depth:int=0, whitespace_adjust:Optional[str]=None) -> None:
+        Logger.Log(message=message, level=logging.INFO, depth=depth, whitespace_adjust=whitespace_adjust)
+
+    @staticmethod
+    def warning(message:str, depth:int=0, whitespace_adjust:Optional[str]=None) -> None:
+        Logger.Log(message=message, level=logging.WARNING, depth=depth, whitespace_adjust=whitespace_adjust)
+
+    @staticmethod
+    def error(message:str, depth:int=0, whitespace_adjust:Optional[str]=None) -> None:
+        Logger.Log(message=message, level=logging.ERROR, depth=depth, whitespace_adjust=whitespace_adjust)
 
     @staticmethod
     def Print(message:str, level=logging.DEBUG) -> None:

--- a/src/ogd/common/utils/Logger.py
+++ b/src/ogd/common/utils/Logger.py
@@ -1,4 +1,5 @@
 import logging
+import textwrap
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional, List
@@ -55,30 +56,40 @@ class Logger:
     # Function to print a method to both the standard out and file logs.
     # Useful for "general" errors where you just want to print out the exception from a "backstop" try-catch block.
     @staticmethod
-    def Log(message:str, level=logging.INFO, depth:int=0) -> None:
+    def Log(message:str, level=logging.INFO, depth:int=0, whitespace_adjust:Optional[str]=None) -> None:
         now = datetime.now().strftime("%y-%m-%d %H:%M:%S")
-        indent = ''.join(['  '*depth])
-        _idt_msg = message.replace("\n", f"\n{' '*9}{indent}")
+        INDENT_WIDTH = 2
+        base_indent = ' '*9
+        user_indent = ' '*INDENT_WIDTH*depth
+        line_indent = f"\n{base_indent}{user_indent}"
+        indented_msg : str
+        match whitespace_adjust:
+            case "lstrip":
+                indented_msg = line_indent.join(line.lstrip() for line in message.split("\n"))
+            case "dedent":
+                indented_msg = textwrap.dedent(message).replace("\n", line_indent)
+            case _:
+                indented_msg = message.replace("\n", line_indent)
         if Logger.file_logger is not None:
             match level:
                 case logging.DEBUG:
-                    Logger.file_logger.debug(f"DEBUG:   {now} {indent}{_idt_msg}")
+                    Logger.file_logger.debug(   f"DEBUG:   {now} {user_indent}{indented_msg}")
                 case logging.INFO:
-                    Logger.file_logger.info( f"INFO:    {now} {indent}{_idt_msg}")
+                    Logger.file_logger.info(    f"INFO:    {now} {user_indent}{indented_msg}")
                 case logging.WARNING:
-                    Logger.file_logger.warning( f"WARNING: {now} {indent}{_idt_msg}")
+                    Logger.file_logger.warning( f"WARNING: {now} {user_indent}{indented_msg}")
                 case logging.ERROR:
-                    Logger.file_logger.error(f"ERROR:   {now} {indent}{_idt_msg}")
+                    Logger.file_logger.error(   f"ERROR:   {now} {user_indent}{indented_msg}")
         if Logger.std_logger is not None:
             match level:
                 case logging.DEBUG:
-                    Logger.std_logger.debug(f"DEBUG:   {indent}{_idt_msg}")
+                    Logger.std_logger.debug(   f"DEBUG:   {user_indent}{indented_msg}")
                 case logging.INFO:
-                    Logger.std_logger.info( f"INFO:    {indent}{_idt_msg}")
+                    Logger.std_logger.info(    f"INFO:    {user_indent}{indented_msg}")
                 case logging.WARNING:
-                    Logger.std_logger.warning( f"WARNING: {indent}{_idt_msg}")
+                    Logger.std_logger.warning( f"WARNING: {user_indent}{indented_msg}")
                 case logging.ERROR:
-                    Logger.std_logger.error(f"ERROR:   {indent}{_idt_msg}")
+                    Logger.std_logger.error(   f"ERROR:   {user_indent}{indented_msg}")
 
     @staticmethod
     def Print(message:str, level=logging.DEBUG) -> None:


### PR DESCRIPTION
Resolves #210 