### PR TITLE
Use `if foo is not None else bar` syntax for schema init functions, instead of `foo or bar`

### DIFF
--- a/src/ogd/common/configs/DataTableConfig.py
+++ b/src/ogd/common/configs/DataTableConfig.py
@@ -72,11 +72,11 @@ class DataTableConfig(Schema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._store_name     : str                       = store_name    or self._parseStoreName(unparsed_elements=unparsed_elements, schema_name=name)
+        self._store_name     : str                       = store_name     if store_name     is not None else self._parseStoreName(unparsed_elements=unparsed_elements, schema_name=name)
         self._store_config   : Optional[DataStoreConfig] = store_config
-        self._schema_name    : str                       = schema_name    or self._parseTableSchemaName(unparsed_elements=unparsed_elements, schema_name=name)
-        self._table_schema   : ts.TableSchema            = table_schema   or TableSchemaFactory.FromFile(filename=self._schema_name)
-        self._table_location : DatabaseLocationSchema    = table_location or self._parseTableLocation(unparsed_elements=unparsed_elements)
+        self._schema_name    : str                       = schema_name    if schema_name    is not None else self._parseTableSchemaName(unparsed_elements=unparsed_elements, schema_name=name)
+        self._table_schema   : ts.TableSchema            = table_schema   if table_schema   is not None else TableSchemaFactory.FromFile(filename=self._schema_name)
+        self._table_location : DatabaseLocationSchema    = table_location if table_location is not None else self._parseTableLocation(unparsed_elements=unparsed_elements)
 
         super().__init__(name=name, other_elements=other_elements)
 

--- a/src/ogd/common/configs/TestConfig.py
+++ b/src/ogd/common/configs/TestConfig.py
@@ -52,8 +52,8 @@ class TestConfig(Config):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._verbose       : bool            = verbose       or self._parseVerbose(unparsed_elements=unparsed_elements, schema_name=name)
-        self._enabled_tests : Dict[str, bool] = enabled_tests or self._parseEnabledTests(unparsed_elements=unparsed_elements, schema_name=name)
+        self._verbose       : bool            = verbose       if verbose       is not None else self._parseVerbose(unparsed_elements=unparsed_elements, schema_name=name)
+        self._enabled_tests : Dict[str, bool] = enabled_tests if enabled_tests is not None else self._parseEnabledTests(unparsed_elements=unparsed_elements, schema_name=name)
         super().__init__(name=name, other_elements=unparsed_elements)
 
     @property

--- a/src/ogd/common/configs/storage/DataStoreConfig.py
+++ b/src/ogd/common/configs/storage/DataStoreConfig.py
@@ -68,7 +68,7 @@ class DataStoreConfig(Config):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._store_type : str = store_type or self._parseStoreType(unparsed_elements=unparsed_elements, schema_name=name)
+        self._store_type : str = store_type if store_type is not None else self._parseStoreType(unparsed_elements=unparsed_elements, schema_name=name)
         super().__init__(name=name, other_elements=unparsed_elements)
 
     @property

--- a/src/ogd/common/configs/storage/DatasetRepositoryConfig.py
+++ b/src/ogd/common/configs/storage/DatasetRepositoryConfig.py
@@ -53,7 +53,7 @@ class DatasetRepositoryConfig(DataStoreConfig):
         fallbacks : Map = other_elements or {}
 
         self._indexing : RepositoryIndexingConfig           = self._toIndexingConfig(indexing=indexing, fallbacks=fallbacks, schema_name=name)
-        self._datasets : Dict[str, DatasetCollectionSchema] = datasets or self._parseDatasets(unparsed_elements=fallbacks, schema_name=name)
+        self._datasets : Dict[str, DatasetCollectionSchema] = datasets if datasets is not None else self._parseDatasets(unparsed_elements=fallbacks, schema_name=name)
         super().__init__(name=name, store_type="Repository", other_elements=other_elements)
 
     def __str__(self) -> str:

--- a/src/ogd/common/configs/storage/DictionaryStoreConfig.py
+++ b/src/ogd/common/configs/storage/DictionaryStoreConfig.py
@@ -50,7 +50,7 @@ class DictionaryStoreConfig(DataStoreConfig):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._location   = location or DictionaryStoreConfig._DEFAULT_LOCATION
+        self._location   = location if location is not None else DictionaryStoreConfig._DEFAULT_LOCATION
         super().__init__(name=name, store_type=self._STORE_TYPE, other_elements=unparsed_elements)
 
     @property

--- a/src/ogd/common/configs/storage/MySQLConfig.py
+++ b/src/ogd/common/configs/storage/MySQLConfig.py
@@ -68,9 +68,9 @@ class MySQLConfig(DataStoreConfig):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._db_location : URLLocationSchema  = db_location   or self._parseLocation(unparsed_elements=unparsed_elements)
-        self._credential  : PasswordCredential = db_credential or self._parseCredential(unparsed_elements=unparsed_elements, schema_name=name)
-        self._ssh_cfg     : SSHConfig          = ssh_cfg       or self._parseSSHConfig(unparsed_elements=unparsed_elements, schema_name=name)
+        self._db_location : URLLocationSchema  = db_location   if db_location   is not None else self._parseLocation(unparsed_elements=unparsed_elements)
+        self._credential  : PasswordCredential = db_credential if db_credential is not None else self._parseCredential(unparsed_elements=unparsed_elements, schema_name=name)
+        self._ssh_cfg     : SSHConfig          = ssh_cfg       if ssh_cfg       is not None else self._parseSSHConfig(unparsed_elements=unparsed_elements, schema_name=name)
         super().__init__(name=name, store_type=self._STORE_TYPE, other_elements=other_elements)
 
     @property

--- a/src/ogd/common/configs/storage/SSHConfig.py
+++ b/src/ogd/common/configs/storage/SSHConfig.py
@@ -54,8 +54,8 @@ class SSHConfig(DataStoreConfig):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._location   : URLLocationSchema  = location       or self._parseLocation(unparsed_elements=unparsed_elements)
-        self._credential : PasswordCredential = ssh_credential or self._parseCredential(unparsed_elements=unparsed_elements)
+        self._location   : URLLocationSchema  = location       if location       is not None else self._parseLocation(unparsed_elements=unparsed_elements)
+        self._credential : PasswordCredential = ssh_credential if ssh_credential is not None else self._parseCredential(unparsed_elements=unparsed_elements)
         super().__init__(name=name, store_type=self._STORE_TYPE, other_elements=other_elements)
 
     @property

--- a/src/ogd/common/configs/storage/credentials/PasswordCredentialConfig.py
+++ b/src/ogd/common/configs/storage/credentials/PasswordCredentialConfig.py
@@ -37,8 +37,8 @@ class PasswordCredential(CredentialConfig):
         :type other_elements: Optional[Map], optional
         """
         fallbacks : Map = other_elements or {}
-        self._user = username or self._parseUser(unparsed_elements=fallbacks, schema_name=name)
-        self._pass = password or self._parsePass(unparsed_elements=fallbacks, schema_name=name)
+        self._user = username if username is not None else self._parseUser(unparsed_elements=fallbacks, schema_name=name)
+        self._pass = password if username is not None else self._parsePass(unparsed_elements=fallbacks, schema_name=name)
         super().__init__(name=name, other_elements=fallbacks)
 
     @property

--- a/src/ogd/common/schemas/datasets/DatasetCollectionSchema.py
+++ b/src/ogd/common/schemas/datasets/DatasetCollectionSchema.py
@@ -52,7 +52,7 @@ class DatasetCollectionSchema(Schema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._datasets : Dict[str, DatasetSchema] = datasets or self._parseDatasets(unparsed_elements=unparsed_elements)
+        self._datasets : Dict[str, DatasetSchema] = datasets if datasets is not None else self._parseDatasets(unparsed_elements=unparsed_elements)
 
         super().__init__(name=name, other_elements={})
 

--- a/src/ogd/common/schemas/datasets/DatasetSchema.py
+++ b/src/ogd/common/schemas/datasets/DatasetSchema.py
@@ -116,28 +116,28 @@ class DatasetSchema(Schema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._key                 : DatasetKey     = key                 or DatasetKey(game_id=game_id, from_date=start_date, to_date=end_date)
+        self._key                 : DatasetKey     = key               if key is not None else DatasetKey(game_id=game_id, from_date=start_date, to_date=end_date)
     # 1. Set dates
-        self._date_modified       : date | str     = date_modified       or self._parseDateModified(unparsed_elements=unparsed_elements, schema_name=name)
-        self._start_date          : date | str     = start_date          or self._parseStartDate(unparsed_elements=unparsed_elements, schema_name=name)
-        self._end_date            : date | str     = end_date            or self._parseEndDate(unparsed_elements=unparsed_elements, schema_name=name)
+        self._date_modified       : date | str     = date_modified    if date_modified is not None else self._parseDateModified(unparsed_elements=unparsed_elements, schema_name=name)
+        self._start_date          : date | str     = start_date       if start_date    is not None else self._parseStartDate(unparsed_elements=unparsed_elements, schema_name=name)
+        self._end_date            : date | str     = end_date         if end_date      is not None else self._parseEndDate(unparsed_elements=unparsed_elements, schema_name=name)
     # 2. Set metadata
-        self._ogd_revision        : str            = ogd_revision        or self._parseOGDRevision(unparsed_elements=unparsed_elements, schema_name=name)
-        self._filters             : Dict[str, str | Filter] = filters    or self._parseFilters(unparsed_elements=unparsed_elements, schema_name=name)
-        self._session_ct          : Optional[int]  = session_ct          or self._parseSessionCount(unparsed_elements=unparsed_elements, schema_name=name)
-        self._player_ct           : Optional[int]  = player_ct           or self._parsePlayerCount(unparsed_elements=unparsed_elements, schema_name=name)
+        self._ogd_revision        : str            = ogd_revision     if ogd_revision is not None else self._parseOGDRevision(unparsed_elements=unparsed_elements, schema_name=name)
+        self._filters             : Dict[str, str | Filter] = filters if filters      is not None else self._parseFilters(unparsed_elements=unparsed_elements, schema_name=name)
+        self._session_ct          : Optional[int]  = session_ct       if session_ct   is not None else self._parseSessionCount(unparsed_elements=unparsed_elements, schema_name=name)
+        self._player_ct           : Optional[int]  = player_ct        if player_ct    is not None else self._parsePlayerCount(unparsed_elements=unparsed_elements, schema_name=name)
     # 3. Set file/template paths
-        self._all_events_file       : Optional[Path] = events_file         or self._parseAllEventsFile(unparsed_elements=unparsed_elements, schema_name=name)
-        self._game_events_file      : Optional[Path] = raw_file            or self._parseGameEventsFile(unparsed_elements=unparsed_elements, schema_name=name)
-        self._events_template       : Optional[Path] = events_template     or self._parseEventsTemplate(unparsed_elements=unparsed_elements, schema_name=name)
-        self._all_features_file     : Optional[Path] = all_feats_file      or self._parseAllFeaturesFile(unparsed_elements=unparsed_elements, schema_name=name)
-        self._all_features_template : Optional[Path] = all_feats_template  or self._parseAllFeaturesTemplate(unparsed_elements=unparsed_elements, schema_name=name)
-        self._sessions_file         : Optional[Path] = sessions_file       or self._parseSessionsFile(unparsed_elements=unparsed_elements, schema_name=name)
-        self._sessions_template     : Optional[Path] = sessions_template   or self._parseSessionsTemplate(unparsed_elements=unparsed_elements, schema_name=name)
-        self._players_file          : Optional[Path] = players_file        or self._parsePlayersFile(unparsed_elements=unparsed_elements, schema_name=name)
-        self._players_template      : Optional[Path] = players_template    or self._parsePlayersTemplate(unparsed_elements=unparsed_elements, schema_name=name)
-        self._population_file       : Optional[Path] = population_file     or self._parsePopulationFile(unparsed_elements=unparsed_elements, schema_name=name)
-        self._population_template   : Optional[Path] = population_template or self._parsePopulationTemplate(unparsed_elements=unparsed_elements, schema_name=name)
+        self._all_events_file       : Optional[Path] = events_file         if events_file         is not None else self._parseAllEventsFile(unparsed_elements=unparsed_elements, schema_name=name)
+        self._game_events_file      : Optional[Path] = raw_file            if raw_file            is not None else self._parseGameEventsFile(unparsed_elements=unparsed_elements, schema_name=name)
+        self._events_template       : Optional[Path] = events_template     if events_template     is not None else self._parseEventsTemplate(unparsed_elements=unparsed_elements, schema_name=name)
+        self._all_features_file     : Optional[Path] = all_feats_file      if all_feats_file      is not None else self._parseAllFeaturesFile(unparsed_elements=unparsed_elements, schema_name=name)
+        self._all_features_template : Optional[Path] = all_feats_template  if all_feats_template  is not None else self._parseAllFeaturesTemplate(unparsed_elements=unparsed_elements, schema_name=name)
+        self._sessions_file         : Optional[Path] = sessions_file       if sessions_file       is not None else self._parseSessionsFile(unparsed_elements=unparsed_elements, schema_name=name)
+        self._sessions_template     : Optional[Path] = sessions_template   if sessions_template   is not None else self._parseSessionsTemplate(unparsed_elements=unparsed_elements, schema_name=name)
+        self._players_file          : Optional[Path] = players_file        if players_file        is not None else self._parsePlayersFile(unparsed_elements=unparsed_elements, schema_name=name)
+        self._players_template      : Optional[Path] = players_template    if players_template    is not None else self._parsePlayersTemplate(unparsed_elements=unparsed_elements, schema_name=name)
+        self._population_file       : Optional[Path] = population_file     if population_file     is not None else self._parsePopulationFile(unparsed_elements=unparsed_elements, schema_name=name)
+        self._population_template   : Optional[Path] = population_template if population_template is not None else self._parsePopulationTemplate(unparsed_elements=unparsed_elements, schema_name=name)
         super().__init__(name=name, other_elements=other_elements)
 
     def __str__(self) -> str:

--- a/src/ogd/common/schemas/events/DataElementSchema.py
+++ b/src/ogd/common/schemas/events/DataElementSchema.py
@@ -50,9 +50,9 @@ class DataElementSchema(Schema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._type        : str                      = element_type or self._parseElementType(unparsed_elements=unparsed_elements, schema_name=name)
-        self._description : str                      = description  or self._parseDescription(unparsed_elements=unparsed_elements, schema_name=name)
-        self._details     : Optional[Dict[str, str]] = details      or self._parseDetails(unparsed_elements=unparsed_elements, schema_name=name)
+        self._type        : str                      = element_type if element_type is not None else self._parseElementType(unparsed_elements=unparsed_elements, schema_name=name)
+        self._description : str                      = description  if description  is not None else self._parseDescription(unparsed_elements=unparsed_elements, schema_name=name)
+        self._details     : Optional[Dict[str, str]] = details      if details      is not None else self._parseDetails(unparsed_elements=unparsed_elements, schema_name=name)
 
         super().__init__(name=name, other_elements=other_elements)
 

--- a/src/ogd/common/schemas/events/EventSchema.py
+++ b/src/ogd/common/schemas/events/EventSchema.py
@@ -48,8 +48,8 @@ class EventSchema(Schema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._description : str                          = description or self._parseDescription(unparsed_elements=unparsed_elements, schema_name=name)
-        self._event_data  : Dict[str, DataElementSchema] = event_data  or self._parseEventDataElements(unparsed_elements=unparsed_elements, schema_name=name)
+        self._description : str                          = description if description is not None else self._parseDescription(unparsed_elements=unparsed_elements, schema_name=name)
+        self._event_data  : Dict[str, DataElementSchema] = event_data  if event_data  is not None else self._parseEventDataElements(unparsed_elements=unparsed_elements, schema_name=name)
 
         super().__init__(name=name, other_elements=other_elements)
 

--- a/src/ogd/common/schemas/events/GameStateSchema.py
+++ b/src/ogd/common/schemas/events/GameStateSchema.py
@@ -52,7 +52,7 @@ class GameStateSchema(Schema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._game_state  : Dict[str, DataElementSchema] = game_state or self._parseGameStateElements(unparsed_elements=unparsed_elements)
+        self._game_state  : Dict[str, DataElementSchema] = game_state if game_state is not None else self._parseGameStateElements(unparsed_elements=unparsed_elements)
 
         super().__init__(name=name, other_elements=other_elements)
 

--- a/src/ogd/common/schemas/events/LoggingSpecificationSchema.py
+++ b/src/ogd/common/schemas/events/LoggingSpecificationSchema.py
@@ -94,11 +94,11 @@ class LoggingSpecificationSchema(Schema):
 
     # 1. define instance vars
         self._game_id     : str                  = game_id
-        self._enum_defs   : Dict[str, List[str]] = enum_defs       or self._parseEnumDefs(unparsed_elements=unparsed_elements, schema_name=name)
-        self._game_state  : Map                  = game_state      or self._parseGameState(unparsed_elements=unparsed_elements, schema_name=name)
-        self._user_data   : Map                  = user_data       or self._parseUserData(unparsed_elements=unparsed_elements, schema_name=name)
-        self._event_list  : List[EventSchema]    = event_list      or self._parseEventList(unparsed_elements=unparsed_elements, schema_name=name)
-        self._log_version : int                  = logging_version or self._parseLogVersion(unparsed_elements=unparsed_elements, schema_name=name)
+        self._enum_defs   : Dict[str, List[str]] = enum_defs       if enum_defs       is not None else self._parseEnumDefs(unparsed_elements=unparsed_elements, schema_name=name)
+        self._game_state  : Map                  = game_state      if game_state      is not None else self._parseGameState(unparsed_elements=unparsed_elements, schema_name=name)
+        self._user_data   : Map                  = user_data       if user_data       is not None else self._parseUserData(unparsed_elements=unparsed_elements, schema_name=name)
+        self._event_list  : List[EventSchema]    = event_list      if event_list      is not None else self._parseEventList(unparsed_elements=unparsed_elements, schema_name=name)
+        self._log_version : int                  = logging_version if logging_version is not None else self._parseLogVersion(unparsed_elements=unparsed_elements, schema_name=name)
 
         super().__init__(name=name, other_elements=other_elements)
 

--- a/src/ogd/common/schemas/locations/DatabaseLocationSchema.py
+++ b/src/ogd/common/schemas/locations/DatabaseLocationSchema.py
@@ -44,8 +44,8 @@ class DatabaseLocationSchema(LocationSchema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._db_name    : str           = database_name or self._parseDatabaseName(unparsed_elements=unparsed_elements, schema_name=name)
-        self._table_name : Optional[str] = table_name    or self._parseTableName(unparsed_elements=unparsed_elements, schema_name=name)
+        self._db_name    : str           = database_name if database_name is not None else self._parseDatabaseName(unparsed_elements=unparsed_elements, schema_name=name)
+        self._table_name : Optional[str] = table_name    if table_name    is not None else self._parseTableName(unparsed_elements=unparsed_elements, schema_name=name)
         super().__init__(name=name, other_elements=other_elements)
 
     @property

--- a/src/ogd/common/schemas/locations/FileLocationSchema.py
+++ b/src/ogd/common/schemas/locations/FileLocationSchema.py
@@ -63,8 +63,8 @@ class FileLocationSchema(LocationSchema):
                 self._filename    = parsed_path[1]
         # 3. If there wasn't a full path, then we move on to just parse folder and filename from dict directly.
             else:
-                self._folder_path = folder_path or self._parsePath(unparsed_elements=unparsed_elements, schema_name=name)
-                self._filename    = filename    or self._parseFilename(unparsed_elements=unparsed_elements, schema_name=name)
+                self._folder_path = folder_path if folder_path is not None else self._parseFolderPath(unparsed_elements=unparsed_elements, schema_name=name)
+                self._filename    = filename    if filename    is not None else self._parseFilename(unparsed_elements=unparsed_elements, schema_name=name)
         super().__init__(name=name, other_elements=other_elements)
 
     @property

--- a/src/ogd/common/schemas/tables/ColumnMapSchema.py
+++ b/src/ogd/common/schemas/tables/ColumnMapSchema.py
@@ -47,9 +47,9 @@ class ColumnMapSchema(Schema):
         # declare and initialize vars
         self._raw_map : Map = other_elements or {}
 
-        self._app_id     : ColumnMapElement = app_id     or self._parseAppID(unparsed_elements=self._raw_map, schema_name=name)
-        self._user_id    : ColumnMapElement = user_id    or self._parseUserID(unparsed_elements=self._raw_map, schema_name=name)
-        self._session_id : ColumnMapElement = session_id or self._parseSessionID(unparsed_elements=self._raw_map, schema_name=name)
+        self._app_id     : ColumnMapElement = app_id     if app_id     is not None else self._parseAppID(unparsed_elements=self._raw_map, schema_name=name)
+        self._user_id    : ColumnMapElement = user_id    if user_id    is not None else self._parseUserID(unparsed_elements=self._raw_map, schema_name=name)
+        self._session_id : ColumnMapElement = session_id if session_id is not None else self._parseSessionID(unparsed_elements=self._raw_map, schema_name=name)
 
         # after loading the file, take the stuff we need and store.
         super().__init__(name=name, other_elements=other_elements)

--- a/src/ogd/common/schemas/tables/ColumnSchema.py
+++ b/src/ogd/common/schemas/tables/ColumnSchema.py
@@ -40,9 +40,9 @@ class ColumnSchema(Schema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._readable    : str = readable    or self._parseReadable(unparsed_elements=unparsed_elements, schema_name=name)
-        self._value_type  : str = value_type  or self._parseValueType(unparsed_elements=unparsed_elements, schema_name=name)
-        self._description : str = description or self._parseDescription(unparsed_elements=unparsed_elements, schema_name=name)
+        self._readable    : str = readable    if readable    is not None else self._parseReadable(unparsed_elements=unparsed_elements, schema_name=name)
+        self._value_type  : str = value_type  if value_type  is not None else self._parseValueType(unparsed_elements=unparsed_elements, schema_name=name)
+        self._description : str = description if description is not None else self._parseDescription(unparsed_elements=unparsed_elements, schema_name=name)
 
         super().__init__(name=name, other_elements=other_elements)
 

--- a/src/ogd/common/schemas/tables/EventMapSchema.py
+++ b/src/ogd/common/schemas/tables/EventMapSchema.py
@@ -86,17 +86,17 @@ class EventMapSchema(ColumnMapSchema):
 
         super().__init__(name=name, app_id=app_id, user_id=user_id, session_id=session_id,
                          other_elements=unparsed_elements)
-        self._app_version          : ColumnMapElement = app_version          or self._parseAppVersion(unparsed_elements=self._raw_map, schema_name=name)
-        self._app_branch           : ColumnMapElement = app_branch           or self._parseAppBranch(unparsed_elements=self._raw_map, schema_name=name)
-        self._log_version          : ColumnMapElement = log_version          or self._parseLogVersion(unparsed_elements=self._raw_map, schema_name=name)
-        self._timestamp            : ColumnMapElement = timestamp            or self._parseTimestamp(unparsed_elements=unparsed_elements, schema_name=name)
-        self._time_offset          : ColumnMapElement = time_offset          or self._parseTimeoffset(unparsed_elements=unparsed_elements, schema_name=name)
-        self._event_sequence_index : ColumnMapElement = event_sequence_index or self._parseSequenceIndex(unparsed_elements=unparsed_elements, schema_name=name)
-        self._event_name           : ColumnMapElement = event_name           or self._parseEventName(unparsed_elements=unparsed_elements, schema_name=name)
-        self._event_source         : ColumnMapElement = event_source         or self._parseEventSource(unparsed_elements=unparsed_elements, schema_name=name)
-        self._event_data           : ColumnMapElement = event_data           or self._parseEventData(unparsed_elements=unparsed_elements, schema_name=name)
-        self._game_state           : ColumnMapElement = game_state           or self._parseGameState(unparsed_elements=unparsed_elements, schema_name=name)
-        self._user_data            : ColumnMapElement = user_data            or self._parseUserData(unparsed_elements=unparsed_elements, schema_name=name)
+        self._app_version          : ColumnMapElement = app_version          if app_version          is not None else self._parseAppVersion(unparsed_elements=self._raw_map, schema_name=name)
+        self._app_branch           : ColumnMapElement = app_branch           if app_branch           is not None else self._parseAppBranch(unparsed_elements=self._raw_map, schema_name=name)
+        self._log_version          : ColumnMapElement = log_version          if log_version          is not None else self._parseLogVersion(unparsed_elements=self._raw_map, schema_name=name)
+        self._timestamp            : ColumnMapElement = timestamp            if timestamp            is not None else self._parseTimestamp(unparsed_elements=unparsed_elements, schema_name=name)
+        self._time_offset          : ColumnMapElement = time_offset          if time_offset          is not None else self._parseTimeoffset(unparsed_elements=unparsed_elements, schema_name=name)
+        self._event_sequence_index : ColumnMapElement = event_sequence_index if event_sequence_index is not None else self._parseSequenceIndex(unparsed_elements=unparsed_elements, schema_name=name)
+        self._event_name           : ColumnMapElement = event_name           if event_name           is not None else self._parseEventName(unparsed_elements=unparsed_elements, schema_name=name)
+        self._event_source         : ColumnMapElement = event_source         if event_source         is not None else self._parseEventSource(unparsed_elements=unparsed_elements, schema_name=name)
+        self._event_data           : ColumnMapElement = event_data           if event_data           is not None else self._parseEventData(unparsed_elements=unparsed_elements, schema_name=name)
+        self._game_state           : ColumnMapElement = game_state           if game_state           is not None else self._parseGameState(unparsed_elements=unparsed_elements, schema_name=name)
+        self._user_data            : ColumnMapElement = user_data            if user_data            is not None else self._parseUserData(unparsed_elements=unparsed_elements, schema_name=name)
 
     def __eq__(self, other:"EventMapSchema"):
         if not isinstance(other, EventMapSchema):

--- a/src/ogd/common/schemas/tables/FeatureMapSchema.py
+++ b/src/ogd/common/schemas/tables/FeatureMapSchema.py
@@ -65,12 +65,12 @@ class FeatureMapSchema(ColumnMapSchema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._feature_name    : ColumnMapElement = feature_name    or self._parseFeatureName(unparsed_elements=unparsed_elements, schema_name=name)
-        self._feature_type    : ColumnMapElement = feature_type    or self._parseFeatureType(unparsed_elements=unparsed_elements, schema_name=name)
-        self._game_unit       : ColumnMapElement = game_unit       or self._parseGameUnit(unparsed_elements=unparsed_elements, schema_name=name)
-        self._game_unit_index : ColumnMapElement = game_unit_index or self._parseGameUnitIndex(unparsed_elements=unparsed_elements, schema_name=name)
-        self._subfeatures     : ColumnMapElement = subfeatures     or self._parseSubfeatures(unparsed_elements=unparsed_elements, schema_name=name)
-        self._values          : ColumnMapElement = values          or self._parseValues(unparsed_elements=unparsed_elements, schema_name=name)
+        self._feature_name    : ColumnMapElement = feature_name    if feature_name    is not None else self._parseFeatureName(unparsed_elements=unparsed_elements, schema_name=name)
+        self._feature_type    : ColumnMapElement = feature_type    if feature_type    is not None else self._parseFeatureType(unparsed_elements=unparsed_elements, schema_name=name)
+        self._game_unit       : ColumnMapElement = game_unit       if game_unit       is not None else self._parseGameUnit(unparsed_elements=unparsed_elements, schema_name=name)
+        self._game_unit_index : ColumnMapElement = game_unit_index if game_unit_index is not None else self._parseGameUnitIndex(unparsed_elements=unparsed_elements, schema_name=name)
+        self._subfeatures     : ColumnMapElement = subfeatures     if subfeatures     is not None else self._parseSubfeatures(unparsed_elements=unparsed_elements, schema_name=name)
+        self._values          : ColumnMapElement = values          if values          is not None else self._parseValues(unparsed_elements=unparsed_elements, schema_name=name)
 
         super().__init__(name=name, app_id=app_id, user_id=user_id, session_id=session_id,
                          other_elements=unparsed_elements)

--- a/src/ogd/common/schemas/tables/FeatureTableSchema.py
+++ b/src/ogd/common/schemas/tables/FeatureTableSchema.py
@@ -65,7 +65,7 @@ class FeatureTableSchema(TableSchema):
         """
         unparsed_elements : Map = other_elements or {}
 
-        self._column_map : FeatureMapSchema = column_map or self._parseColumnMap(unparsed_elements=unparsed_elements, schema_name=name)
+        self._column_map : FeatureMapSchema = column_map if column_map is not None else self._parseColumnMap(unparsed_elements=unparsed_elements, schema_name=name)
         super().__init__(name=name, columns=columns, other_elements=unparsed_elements)
 
     # *** IMPLEMENT ABSTRACT FUNCTIONS ***

--- a/src/ogd/common/schemas/tables/TableSchema.py
+++ b/src/ogd/common/schemas/tables/TableSchema.py
@@ -164,7 +164,7 @@ class TableSchema(Schema):
 
         # declare and initialize vars
         # self._schema            : Optional[Dict[str, Any]] = all_elements
-        self._table_columns : List[ColumnSchema] = columns    or self._parseColumns(unparsed_elements=unparsed_elements, schema_name=name)
+        self._table_columns : List[ColumnSchema] = columns if columns is not None else self._parseColumns(unparsed_elements=unparsed_elements, schema_name=name)
 
         # after loading the file, take the stuff we need and store.
         super().__init__(name=name, other_elements=other_elements)


### PR DESCRIPTION
The "or" syntax meant the init functions would try to do parsing even when user had intended to pass e.g. an empty list. Now, we only go to parsing if we were given `None` as input.

Resolves #123 