### PR TITLE
`DataTableConfig` constructor accepts string inputs for its `TableSchema` and `DataStoreConfig`, rather than having separate string params

### DIFF
--- a/tests/cases/configs/test_DataTableConfig.py
+++ b/tests/cases/configs/test_DataTableConfig.py
@@ -35,8 +35,8 @@ class test_DataTableConfig(TestCase):
         }
         cls.test_schema = DataTableConfig(
             name="Game Source Schema",
-            store_name="AQUALAB_BQ",
-            schema_name="OPENGAMEDATA_BIGQUERY",
+            store="AQUALAB_BQ",
+            table_schema="OPENGAMEDATA_BIGQUERY",
             table_location=DatabaseLocationSchema(name="DBLocation", database_name="aqualab", table_name="aqualab_daily"),
             other_elements={ "foo":"bar" }
         )

--- a/tests/cases/models/test_EventSet.py
+++ b/tests/cases/models/test_EventSet.py
@@ -66,10 +66,9 @@ class test_EventSet(TestCase):
         # 2. Set up local instance of testing class
         _cfg = DataTableConfig(
             name="FILE SOURCE",
-            store_name=None,
-            schema_name="OGD_EVENT_FILE",
+            store=None,
+            table_schema="OGD_EVENT_FILE",
             table_location=DatabaseLocationSchema(name="TestLocation", database_name="location", table_name=None),
-            store_config=None
         )
         CSVI = CSVInterface(config=_cfg, fail_fast=False)
         cls.events : EventSet = CSVI.GetEventSet(filters=DatasetFilterCollection(), fallbacks={})


### PR DESCRIPTION
Resolves #227